### PR TITLE
[feat, chore] 소셜 로그인 구현 & 응답 객체 통일 & 에러 처리 & 액세스 토큰 재발행 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -22,6 +22,16 @@ dependencies {
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    // OAuth 2.0
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.2'
+    // 시큐리티
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    testImplementation 'org.springframework.security:spring-security-test'
     // 롬복
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/org/dgu/backend/auth/handler/OAuthLoginFailureHandler.java
+++ b/backend/src/main/java/org/dgu/backend/auth/handler/OAuthLoginFailureHandler.java
@@ -1,0 +1,24 @@
+package org.dgu.backend.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.error("LOGIN FAILED : {}", exception.getMessage());
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/auth/handler/OAuthLoginSuccessHandler.java
+++ b/backend/src/main/java/org/dgu/backend/auth/handler/OAuthLoginSuccessHandler.java
@@ -1,0 +1,112 @@
+package org.dgu.backend.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dgu.backend.auth.info.GoogleUserInfo;
+import org.dgu.backend.auth.info.KakaoUserInfo;
+import org.dgu.backend.auth.info.NaverUserInfo;
+import org.dgu.backend.auth.info.OAuth2UserInfo;
+import org.dgu.backend.domain.RefreshToken;
+import org.dgu.backend.domain.User;
+import org.dgu.backend.repository.RefreshTokenRepository;
+import org.dgu.backend.repository.UserRepository;
+import org.dgu.backend.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Value("${jwt.redirect}")
+    private String REDIRECT_URI; // 프론트엔드로 Jwt 토큰을 리다이렉트할 URI
+
+    @Value("${jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME; // 액세스 토큰 유효기간
+
+    @Value("${jwt.refresh-token.expiration-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME; // 리프레쉬 토큰 유효기간
+
+    private OAuth2UserInfo oAuth2UserInfo = null;
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication; // 토큰
+        final String provider = token.getAuthorizedClientRegistrationId(); // provider 추출
+
+        // 구글 || 카카오 || 네이버 로그인 요청
+        switch (provider) {
+            case "google" -> {
+                log.info("구글 로그인 요청");
+                oAuth2UserInfo = new GoogleUserInfo(token.getPrincipal().getAttributes());
+            }
+            case "kakao" -> {
+                log.info("카카오 로그인 요청");
+                oAuth2UserInfo = new KakaoUserInfo(token.getPrincipal().getAttributes());
+            }
+            case "naver" -> {
+                log.info("네이버 로그인 요청");
+                oAuth2UserInfo = new NaverUserInfo((Map<String, Object>) token.getPrincipal().getAttributes().get("response"));
+            }
+        }
+
+        // 정보 추출
+        String providerId = oAuth2UserInfo.getProviderId();
+        String name = oAuth2UserInfo.getName();
+
+        User existUser = userRepository.findByProviderId(providerId);
+        User user;
+
+        if (existUser == null) {
+            // 신규 유저인 경우
+            log.info("신규 유저입니다. 등록을 진행합니다.");
+
+            user = User.builder()
+                    .userId(UUID.randomUUID())
+                    .name(name)
+                    .provider(provider)
+                    .providerId(providerId)
+                    .build();
+            userRepository.save(user);
+        } else {
+            // 기존 유저인 경우
+            log.info("기존 유저입니다.");
+            user = existUser;
+        }
+
+        log.info("유저 이름 : {}", name);
+        log.info("PROVIDER : {}", provider);
+        log.info("PROVIDER_ID : {}", providerId);
+
+        // 리프레쉬 토큰 발급 후 저장
+        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId(), REFRESH_TOKEN_EXPIRATION_TIME);
+
+        RefreshToken newRefreshToken = RefreshToken.builder()
+                                        .userId(user.getUserId())
+                                        .token(refreshToken)
+                                        .build();
+        refreshTokenRepository.save(newRefreshToken);
+
+        // 액세스 토큰 발급
+        String accessToken = jwtUtil.generateAccessToken(user.getUserId(), ACCESS_TOKEN_EXPIRATION_TIME);
+
+        // 이름, 액세스 토큰, 리프레쉬 토큰을 담아 리다이렉트
+        String encodedName = URLEncoder.encode(name, "UTF-8");
+        String redirectUri = String.format(REDIRECT_URI, encodedName, accessToken, refreshToken);
+        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/auth/info/GoogleUserInfo.java
+++ b/backend/src/main/java/org/dgu/backend/auth/info/GoogleUserInfo.java
@@ -1,0 +1,26 @@
+package org.dgu.backend.auth.info;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+    private Map<String, Object> attributes;
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/auth/info/KakaoUserInfo.java
+++ b/backend/src/main/java/org/dgu/backend/auth/info/KakaoUserInfo.java
@@ -1,0 +1,28 @@
+package org.dgu.backend.auth.info;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+    private Map<String, Object> attributes;
+
+    @Override
+    public String getProviderId() {
+        // Long 타입이기 때문에 toString으로 변환
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getName() {
+        // kakao_account라는 Map에서 추출
+        return (String) ((Map) attributes.get("properties")).get("nickname");
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/auth/info/NaverUserInfo.java
+++ b/backend/src/main/java/org/dgu/backend/auth/info/NaverUserInfo.java
@@ -1,0 +1,26 @@
+package org.dgu.backend.auth.info;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+@AllArgsConstructor
+public class NaverUserInfo implements OAuth2UserInfo {
+
+    private Map<String, Object> attributes;
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/auth/info/OAuth2UserInfo.java
+++ b/backend/src/main/java/org/dgu/backend/auth/info/OAuth2UserInfo.java
@@ -1,0 +1,7 @@
+package org.dgu.backend.auth.info;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getProvider();
+    String getName();
+}

--- a/backend/src/main/java/org/dgu/backend/common/ApiResponse.java
+++ b/backend/src/main/java/org/dgu/backend/common/ApiResponse.java
@@ -1,0 +1,30 @@
+package org.dgu.backend.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.dgu.backend.common.code.BaseCode;
+import org.dgu.backend.common.code.BaseErrorCode;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiResponse<T> {
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T payload;
+    public static <T> ResponseEntity<ApiResponse<T>> onSuccess(BaseCode code, T data) {
+        ApiResponse<T> response = new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), data);
+        return ResponseEntity.status(code.getReasonHttpStatus().getHttpStatus()).body(response);
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> onFailure(BaseErrorCode code) {
+        ApiResponse<T> response = new ApiResponse<>(false, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), null);
+        return ResponseEntity.status(code.getReasonHttpStatus().getHttpStatus()).body(response);
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/common/code/BaseCode.java
+++ b/backend/src/main/java/org/dgu/backend/common/code/BaseCode.java
@@ -1,0 +1,10 @@
+package org.dgu.backend.common.code;
+
+
+import org.dgu.backend.common.dto.ReasonDto;
+
+public interface BaseCode {
+    public ReasonDto getReason();
+
+    public ReasonDto getReasonHttpStatus();
+}

--- a/backend/src/main/java/org/dgu/backend/common/code/BaseErrorCode.java
+++ b/backend/src/main/java/org/dgu/backend/common/code/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package org.dgu.backend.common.code;
+
+
+import org.dgu.backend.common.dto.ErrorReasonDto;
+
+public interface BaseErrorCode {
+    public ErrorReasonDto getReason();
+
+    public ErrorReasonDto getReasonHttpStatus();
+}

--- a/backend/src/main/java/org/dgu/backend/common/constant/ErrorStatus.java
+++ b/backend/src/main/java/org/dgu/backend/common/constant/ErrorStatus.java
@@ -1,0 +1,40 @@
+package org.dgu.backend.common.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.dgu.backend.common.code.BaseErrorCode;
+import org.dgu.backend.common.dto.ErrorReasonDto;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 전역 에러
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"500", "서버에서 요청을 처리 하는 동안 오류가 발생했습니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"400", "입력 값이 잘못된 요청 입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"401", "인증이 필요 합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "403", "금지된 요청 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/common/constant/SuccessStatus.java
+++ b/backend/src/main/java/org/dgu/backend/common/constant/SuccessStatus.java
@@ -1,0 +1,41 @@
+package org.dgu.backend.common.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.dgu.backend.common.code.BaseCode;
+import org.dgu.backend.common.dto.ReasonDto;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    // 전역 응답 코드
+    _OK(HttpStatus.OK, "200", "성공입니다."),
+    _CREATED(HttpStatus.CREATED, "201", "생성에 성공했습니다."),
+
+    // 커스텀 응답 코드
+    _CREATED_ACCESS_TOKEN(HttpStatus.CREATED, "201", "액세스 토큰 재발행에 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/common/dto/ErrorReasonDto.java
+++ b/backend/src/main/java/org/dgu/backend/common/dto/ErrorReasonDto.java
@@ -1,0 +1,14 @@
+package org.dgu.backend.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDto {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/backend/src/main/java/org/dgu/backend/common/dto/ReasonDto.java
+++ b/backend/src/main/java/org/dgu/backend/common/dto/ReasonDto.java
@@ -1,0 +1,14 @@
+package org.dgu.backend.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDto {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/backend/src/main/java/org/dgu/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/org/dgu/backend/config/SecurityConfig.java
@@ -1,0 +1,56 @@
+package org.dgu.backend.config;
+
+import lombok.RequiredArgsConstructor;
+import org.dgu.backend.auth.handler.OAuthLoginFailureHandler;
+import org.dgu.backend.auth.handler.OAuthLoginSuccessHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+    private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
+
+    // CORS 설정
+    CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            CorsConfiguration config = new CorsConfiguration();
+            config.setAllowedHeaders(Collections.singletonList("*"));
+            config.setAllowedMethods(Collections.singletonList("*"));
+            config.setAllowedOriginPatterns(Collections.singletonList("*")); // 허용할 origin
+            config.setAllowCredentials(true);
+            return config;
+        };
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.
+                httpBasic(HttpBasicConfigurer::disable)
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource())) // CORS 설정 추가
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize ->
+                        authorize
+                                .requestMatchers("/**").permitAll()
+                )
+
+                .oauth2Login(oauth -> // OAuth2 로그인 기능에 대한 여러 설정의 진입점
+                        oauth
+                                .successHandler(oAuthLoginSuccessHandler) // 로그인 성공 시 핸들러
+                                .failureHandler(oAuthLoginFailureHandler) // 로그인 실패 시 핸들러
+                );
+
+        return httpSecurity.build();
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/controller/AuthController.java
+++ b/backend/src/main/java/org/dgu/backend/controller/AuthController.java
@@ -1,0 +1,33 @@
+package org.dgu.backend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.dgu.backend.common.ApiResponse;
+import org.dgu.backend.common.constant.SuccessStatus;
+import org.dgu.backend.dto.response.TokenResponse;
+import org.dgu.backend.exception.TokenErrorResult;
+import org.dgu.backend.exception.TokenException;
+import org.dgu.backend.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    // 액세스 토큰을 재발행하는 API
+    @GetMapping("/reissue/access-token")
+    public ResponseEntity<ApiResponse<Object>> reissueAccessToken(
+            @RequestHeader("Authorization") String authorizationHeader) {
+
+        try {
+            TokenResponse accessToken = authService.reissueAccessToken(authorizationHeader);
+            return ApiResponse.onSuccess(SuccessStatus._CREATED_ACCESS_TOKEN, accessToken);
+        } catch (TokenException e) {
+            // 토큰 예외 처리
+            TokenErrorResult errorResult = e.getTokenErrorResult();
+            return ApiResponse.onFailure(errorResult);
+        }
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/controller/CandleInfoController.java
+++ b/backend/src/main/java/org/dgu/backend/controller/CandleInfoController.java
@@ -1,6 +1,5 @@
 package org.dgu.backend.controller;
 
-import com.google.common.util.concurrent.RateLimiter;
 import lombok.RequiredArgsConstructor;
 import org.dgu.backend.service.CandleInfoService;
 import org.dgu.backend.util.CandleDataCollector;

--- a/backend/src/main/java/org/dgu/backend/domain/RefreshToken.java
+++ b/backend/src/main/java/org/dgu/backend/domain/RefreshToken.java
@@ -1,0 +1,25 @@
+package org.dgu.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_tokens_id")
+    private Long id;
+
+    @Column(name = "users_uuid", columnDefinition = "BINARY(16)", unique = true)
+    private UUID userId;
+
+    @Column(name = "token", nullable = false)
+    private String token;
+}

--- a/backend/src/main/java/org/dgu/backend/domain/User.java
+++ b/backend/src/main/java/org/dgu/backend/domain/User.java
@@ -1,0 +1,42 @@
+package org.dgu.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "users_id")
+    private Long id;
+
+    @Column(name = "users_uuid", columnDefinition = "BINARY(16)", unique = true)
+    private UUID userId;
+
+    @Column(name = "name", nullable = false, length = 5)
+    private String name;
+
+    @Column(name = "provider", nullable = false, length = 10)
+    private String provider;
+
+    @Column(name = "provider_id", nullable = false, length = 50)
+    private String providerId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, length = 20)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", length = 20)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/org/dgu/backend/dto/response/TokenResponse.java
+++ b/backend/src/main/java/org/dgu/backend/dto/response/TokenResponse.java
@@ -1,0 +1,12 @@
+package org.dgu.backend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class TokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+}

--- a/backend/src/main/java/org/dgu/backend/exception/TokenErrorResult.java
+++ b/backend/src/main/java/org/dgu/backend/exception/TokenErrorResult.java
@@ -1,0 +1,38 @@
+package org.dgu.backend.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.dgu.backend.common.code.BaseErrorCode;
+import org.dgu.backend.common.dto.ErrorReasonDto;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenErrorResult implements BaseErrorCode {
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "401", "유효하지 않은 토큰입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "401", "유효하지 않은 액세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "401", "유효하지 않은 리프레쉬 토큰입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/exception/TokenException.java
+++ b/backend/src/main/java/org/dgu/backend/exception/TokenException.java
@@ -1,0 +1,15 @@
+package org.dgu.backend.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenException extends RuntimeException {
+    private final TokenErrorResult tokenErrorResult;
+
+    @Override
+    public String getMessage() {
+        return tokenErrorResult.getMessage();
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/exception/UserErrorResult.java
+++ b/backend/src/main/java/org/dgu/backend/exception/UserErrorResult.java
@@ -1,0 +1,36 @@
+package org.dgu.backend.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.dgu.backend.common.code.BaseErrorCode;
+import org.dgu.backend.common.dto.ErrorReasonDto;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorResult implements BaseErrorCode  {
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "404", "존재하지 않는 유저입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/exception/UserException.java
+++ b/backend/src/main/java/org/dgu/backend/exception/UserException.java
@@ -1,0 +1,15 @@
+package org.dgu.backend.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserException extends RuntimeException {
+    private final UserErrorResult userErrorResult;
+
+    @Override
+    public String getMessage() {
+        return userErrorResult.getMessage();
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/org/dgu/backend/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package org.dgu.backend.repository;
+
+import org.dgu.backend.domain.RefreshToken;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+@Repository
+public interface RefreshTokenRepository extends  JpaRepository<RefreshToken,Long> {
+    @Query("SELECT u FROM RefreshToken u WHERE u.userId = :userId")
+    RefreshToken findByUserId(UUID userId);
+}

--- a/backend/src/main/java/org/dgu/backend/repository/UserRepository.java
+++ b/backend/src/main/java/org/dgu/backend/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package org.dgu.backend.repository;
+
+import org.dgu.backend.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserRepository extends JpaRepository<User,Long> {
+    @Query("SELECT u FROM User u WHERE u.userId = :userId")
+    Optional<User> findByUserId(UUID userId);
+
+    User findByProviderId(String providerId);
+}

--- a/backend/src/main/java/org/dgu/backend/service/AuthService.java
+++ b/backend/src/main/java/org/dgu/backend/service/AuthService.java
@@ -1,0 +1,7 @@
+package org.dgu.backend.service;
+
+import org.dgu.backend.dto.response.TokenResponse;
+
+public interface AuthService {
+    TokenResponse reissueAccessToken(String authorizationHeader);
+}

--- a/backend/src/main/java/org/dgu/backend/service/AuthServiceImpl.java
+++ b/backend/src/main/java/org/dgu/backend/service/AuthServiceImpl.java
@@ -1,0 +1,43 @@
+package org.dgu.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.dgu.backend.domain.RefreshToken;
+import org.dgu.backend.dto.response.TokenResponse;
+import org.dgu.backend.exception.TokenErrorResult;
+import org.dgu.backend.exception.TokenException;
+import org.dgu.backend.repository.RefreshTokenRepository;
+import org.dgu.backend.util.JwtUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService{
+    @Value("${jwt.access-token.expiration-time}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME; // 액세스 토큰 유효기간
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtUtil jwtUtil;
+    @Override
+    public TokenResponse reissueAccessToken(String authorizationHeader) {
+        String refreshToken = jwtUtil.getTokenFromHeader(authorizationHeader);
+        String userId = jwtUtil.getUserIdFromToken(refreshToken);
+        RefreshToken existRefreshToken = refreshTokenRepository.findByUserId(UUID.fromString(userId));
+        String accessToken = null;
+
+        if (!existRefreshToken.getToken().equals(refreshToken) || jwtUtil.isTokenExpired(refreshToken)) {
+            // 리프레쉬 토큰이 다르거나, 만료된 경우
+            refreshTokenRepository.delete(existRefreshToken);
+            throw new TokenException(TokenErrorResult.INVALID_REFRESH_TOKEN); // 401 에러를 던져 재로그인을 요청
+        } else {
+            // 액세스 토큰 재발급
+            accessToken = jwtUtil.generateAccessToken(UUID.fromString(userId), ACCESS_TOKEN_EXPIRATION_TIME);
+        }
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/backend/src/main/java/org/dgu/backend/util/JwtUtil.java
+++ b/backend/src/main/java/org/dgu/backend/util/JwtUtil.java
@@ -1,0 +1,91 @@
+package org.dgu.backend.util;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.dgu.backend.exception.TokenErrorResult;
+import org.dgu.backend.exception.TokenException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class JwtUtil {
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
+
+    private SecretKey getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(this.SECRET_KEY);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // 액세스 토큰을 발급하는 메서드
+    public String generateAccessToken(UUID userId, long expirationMillis) {
+        log.info("액세스 토큰이 발행되었습니다.");
+
+        return Jwts.builder()
+                .claim("userId", userId.toString()) // 클레임에 userId 추가
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMillis))
+                .signWith(this.getSigningKey())
+                .compact();
+    }
+
+    // 리프레쉬 토큰을 발급하는 메서드
+    public String generateRefreshToken(UUID userId, long expirationMillis) {
+        log.info("리프레쉬 토큰이 발행되었습니다.");
+
+        return Jwts.builder()
+                .claim("userId", userId.toString()) // 클레임에 userId 추가
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMillis))
+                .signWith(this.getSigningKey())
+                .compact();
+    }
+
+    // 응답 헤더에서 액세스 토큰을 반환하는 메서드
+    public String getTokenFromHeader(String authorizationHeader) {
+        return authorizationHeader.substring(7);
+    }
+
+    // 토큰에서 유저 id를 반환하는 메서드
+    public String getUserIdFromToken(String token) {
+        try {
+            String userId = Jwts.parser()
+                    .verifyWith(this.getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("userId", String.class);
+            log.info("유저 id를 반환합니다.");
+            return userId;
+        } catch (JwtException | IllegalArgumentException e) {
+            // 토큰이 유효하지 않은 경우
+            log.warn("유효하지 않은 토큰입니다.");
+            throw new TokenException(TokenErrorResult.INVALID_TOKEN);
+        }
+    }
+
+    // Jwt 토큰의 유효기간을 확인하는 메서드
+    public boolean isTokenExpired(String token) {
+        try {
+            Date expirationDate = Jwts.parser()
+                    .verifyWith(this.getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getExpiration();
+            log.info("토큰의 유효기간을 확인합니다.");
+            return expirationDate.before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            // 토큰이 유효하지 않은 경우
+            log.warn("유효하지 않은 토큰입니다.");
+            throw new TokenException(TokenErrorResult.INVALID_TOKEN);
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,17 +6,77 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
-    hibernate:
-      ddl-auto: update
-      dialect: org.hibernate.dialect.MySQL8Dialect
     properties:
       hibernate:
-        show_sql: true
-        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+
+    defer-datasource-initialization: true
+    open-in-view: false
+    generate-ddl: true
+    show-sql: true
 
   sql:
     init:
       mode: always
+
+  security:
+    oauth2:
+      client:
+        registration:
+
+          google:
+            client-id: ${OAUTH_GOOGLE_CLIENT_ID}
+            client-secret: ${OAUTH_GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            #redirect-uri: ${OAUTH_GOOGLE_REDIRECT_URI}
+
+          kakao:
+            client-id: ${OAUTH_KAKAO_CLIENT_ID}
+            client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
+            scope:
+              - profile_nickname
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            #redirect-uri: ${OAUTH_KAKAO_REDIRECT_URI}
+            client-name: Kakao
+            client-authentication-method: client_secret_post
+
+          naver:
+            client-id: ${OAUTH_NAVER_CLIENT_ID}
+            client-secret: ${OAUTH_NAVER_CLIENT_SECRET}
+            scope:
+              - name
+            client-name: Naver
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            #redirect-uri: ${OAUTH_NAVER_REDIRECT_URI}
+
+        provider:
+
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+jwt:
+  secret: ${JWT_SECRET}
+  redirect: ${JWT_REDIRECT_URI}
+  access-token:
+    expiration-time: ${ACCESS_TOKEN_EXPIRATION_TIME}
+  refresh-token:
+    expiration-time: ${REFRESH_TOKEN_EXPIRATION_TIME}
 
 upbit-open-api:
   access-key: ${UPBIT_ACCESS_KEY}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,24 +1,15 @@
-CREATE TABLE IF NOT EXISTS candles (
-                                       candles_id INT NOT NULL AUTO_INCREMENT,
-                                       candles_name VARCHAR(255),
-    korean_name VARCHAR(255),
-    PRIMARY KEY (candles_id)
-    );
+INSERT INTO candles (candles_name, korean_name) VALUES
 
-INSERT INTO candles (candles_id, candles_name, korean_name)
-SELECT * FROM (
-                  SELECT 1, 'minutes1', '1분봉' UNION ALL
-                  SELECT 2, 'minutes3', '3분봉' UNION ALL
-                  SELECT 3, 'minutes5', '5분봉' UNION ALL
-                  SELECT 4, 'minutes10', '10분봉' UNION ALL
-                  SELECT 5, 'minutes15', '15분봉' UNION ALL
-                  SELECT 6, 'minutes30', '30분봉' UNION ALL
-                  SELECT 7, 'minutes60', '60분봉' UNION ALL
-                  SELECT 8, 'minutes240', '240분봉' UNION ALL
-                  SELECT 9, 'days', '일봉' UNION ALL
-                  SELECT 10, 'weeks', '주봉' UNION ALL
-                  SELECT 11, 'months', '월봉'
-              ) AS tmp
-WHERE NOT EXISTS (
-    SELECT candles_id FROM candles WHERE candles_id IN (1)
-);
+                  ('minutes1', '1분봉'),
+                  ('minutes3', '3분봉'),
+                  ('minutes5', '5분봉'),
+                  ('minutes10', '10분봉'),
+                  ('minutes15', '15분봉'),
+                  ('minutes30', '30분봉'),
+                  ('minutes60', '60분봉'),
+                  ('minutes240', '240분봉'),
+                  ('days', '일봉'),
+                  ('weeks', '주봉'),
+                  ('months', '월봉')
+
+ON DUPLICATE KEY UPDATE candles_id = candles_id;


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 구글 소셜 로그인 구현
- [x] 카카오 소셜 로그인 구현
- [x] 네이버 소셜 로그인 구현
- [x] 코드 리팩토링
- [x] 응답 객체 통일
- [x] 에러 처리 기능 구현
- [x] 액세스 토큰 재발행 API 구현

---

## 📝 작업 내용
### 구글
<img width="1117" alt="스크린샷 2024-04-18 오전 2 02 55" src="https://github.com/CSID-DGU/2024-1-SCS4031-01-owl-4/assets/113084292/bafa00cb-7c5b-471f-90c5-354e10ad3756">

<img width="1335" alt="스크린샷 2024-04-18 오전 2 32 53" src="https://github.com/CSID-DGU/2024-1-SCS4031-01-owl-4/assets/113084292/7dc0a24d-c9e9-4320-93a8-a7b5ad6f48e0">

### 카카오
<img width="613" alt="스크린샷 2024-04-18 오전 2 02 04" src="https://github.com/CSID-DGU/2024-1-SCS4031-01-owl-4/assets/113084292/80def74e-0920-4e5f-89ae-52389ea926e7">

<img width="1322" alt="스크린샷 2024-04-18 오전 2 33 17" src="https://github.com/CSID-DGU/2024-1-SCS4031-01-owl-4/assets/113084292/738926c4-f6d3-4a0f-b25b-3f084f6742f0">

### 네이버
<img width="619" alt="스크린샷 2024-04-18 오전 1 57 06" src="https://github.com/CSID-DGU/2024-1-SCS4031-01-owl-4/assets/113084292/87139fda-4965-4b29-81a5-90c2ae36fd3f">

<img width="1321" alt="스크린샷 2024-04-18 오전 2 33 33" src="https://github.com/CSID-DGU/2024-1-SCS4031-01-owl-4/assets/113084292/d6188669-65c7-445b-99e8-939227d07c91">

### 액세스 토큰 재발행
`http://localhost:8080/api/v1/reissue/access-token`

<img width="1267" alt="스크린샷 2024-04-18 오후 3 40 59" src="https://github.com/CSID-DGU/2024-1-SCS4031-01-owl-4/assets/113084292/8f0b0115-6379-4687-a94c-621781655218">

### 토큰 관련 인증 오류

<img width="1108" alt="스크린샷 2024-04-18 오후 3 41 18" src="https://github.com/CSID-DGU/2024-1-SCS4031-01-owl-4/assets/113084292/5fc5f276-f949-47dc-ba49-40bb8a399afd">

=> 401에러 발생 시, 유저 재로그인 시행

---

## ✏️ 관련 이슈
#5 

---

## 🎸 기타 사항 or 추가 코멘트
- 로그인 시 프론트에서 처리해야 할 사항은 노션에 정리해 둠
