### PR TITLE
[feat, refactor] 리프레쉬 토큰은 쿠키에 담는 방식으로 리팩토링 완료

### DIFF
--- a/backend/src/main/java/org/dgu/backend/auth/handler/OAuthLoginSuccessHandler.java
+++ b/backend/src/main/java/org/dgu/backend/auth/handler/OAuthLoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package org.dgu.backend.auth.handler;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.dgu.backend.domain.RefreshToken;
 import org.dgu.backend.domain.User;
 import org.dgu.backend.repository.RefreshTokenRepository;
 import org.dgu.backend.repository.UserRepository;
+import org.dgu.backend.util.CookieUtil;
 import org.dgu.backend.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -40,6 +42,7 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     private OAuth2UserInfo oAuth2UserInfo = null;
 
     private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
 
@@ -93,12 +96,14 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         log.info("PROVIDER : {}", provider);
         log.info("PROVIDER_ID : {}", providerId);
 
-        // 리프레쉬 토큰 발급 후 저장
-        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId(), REFRESH_TOKEN_EXPIRATION_TIME);
+        // 리프레쉬 토큰이 담긴 쿠키 생성 후 설정
+        Cookie cookie = cookieUtil.createCookie(user.getUserId(), REFRESH_TOKEN_EXPIRATION_TIME);
+        response.addCookie(cookie);
 
+        // 새로운 리프레쉬 토큰 DB 저장
         RefreshToken newRefreshToken = RefreshToken.builder()
                 .userId(user.getUserId())
-                .token(refreshToken)
+                .token(cookie.getValue())
                 .build();
         refreshTokenRepository.save(newRefreshToken);
 
@@ -107,7 +112,7 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
 
         // 이름, 액세스 토큰, 리프레쉬 토큰을 담아 리다이렉트
         String encodedName = URLEncoder.encode(name, "UTF-8");
-        String redirectUri = String.format(REDIRECT_URI, encodedName, accessToken, refreshToken);
+        String redirectUri = String.format(REDIRECT_URI, encodedName, accessToken);
         getRedirectStrategy().sendRedirect(request, response, redirectUri);
     }
 }

--- a/backend/src/main/java/org/dgu/backend/controller/AuthController.java
+++ b/backend/src/main/java/org/dgu/backend/controller/AuthController.java
@@ -1,5 +1,7 @@
 package org.dgu.backend.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.dgu.backend.common.ApiResponse;
 import org.dgu.backend.common.constant.SuccessStatus;
@@ -17,9 +19,10 @@ public class AuthController {
     // 액세스 토큰을 재발행하는 API
     @GetMapping("/reissue/access-token")
     public ResponseEntity<ApiResponse<Object>> reissueAccessToken(
-            @RequestHeader("Authorization") String authorizationHeader) {
+            HttpServletRequest request,
+            HttpServletResponse response) {
 
-        TokenResponse accessToken = authService.reissueAccessToken(authorizationHeader);
+        TokenResponse accessToken = authService.reissueAccessToken(request, response);
         return ApiResponse.onSuccess(SuccessStatus._CREATED_ACCESS_TOKEN, accessToken);
     }
 }

--- a/backend/src/main/java/org/dgu/backend/service/AuthService.java
+++ b/backend/src/main/java/org/dgu/backend/service/AuthService.java
@@ -1,7 +1,9 @@
 package org.dgu.backend.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.dgu.backend.dto.response.TokenResponse;
 
 public interface AuthService {
-    TokenResponse reissueAccessToken(String authorizationHeader);
+    TokenResponse reissueAccessToken(HttpServletRequest request, HttpServletResponse response);
 }

--- a/backend/src/main/java/org/dgu/backend/service/AuthServiceImpl.java
+++ b/backend/src/main/java/org/dgu/backend/service/AuthServiceImpl.java
@@ -1,11 +1,15 @@
 package org.dgu.backend.service;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.dgu.backend.domain.RefreshToken;
 import org.dgu.backend.dto.response.TokenResponse;
 import org.dgu.backend.exception.TokenErrorResult;
 import org.dgu.backend.exception.TokenException;
 import org.dgu.backend.repository.RefreshTokenRepository;
+import org.dgu.backend.util.CookieUtil;
 import org.dgu.backend.util.JwtUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -18,27 +22,46 @@ public class AuthServiceImpl implements AuthService{
     @Value("${jwt.access-token.expiration-time}")
     private long ACCESS_TOKEN_EXPIRATION_TIME; // 액세스 토큰 유효기간
 
+    @Value("${jwt.refresh-token.expiration-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME; // 리프레쉬 토큰 유효기간
+
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
 
     @Override
-    public TokenResponse reissueAccessToken(String authorizationHeader) {
-        String refreshToken = jwtUtil.getTokenFromHeader(authorizationHeader);
-        String userId = jwtUtil.getUserIdFromToken(refreshToken);
-        RefreshToken existRefreshToken = refreshTokenRepository.findByUserId(UUID.fromString(userId));
-        String accessToken = null;
+    public TokenResponse reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = cookieUtil.getCookie(request);
+        String refreshToken = cookie.getValue();
+        UUID userId = UUID.fromString(jwtUtil.getUserIdFromToken(refreshToken));
+        RefreshToken existRefreshToken = refreshTokenRepository.findByUserId(userId);
+        String newAccessToken;
 
         if (!existRefreshToken.getToken().equals(refreshToken) || jwtUtil.isTokenExpired(refreshToken)) {
             // 리프레쉬 토큰이 다르거나, 만료된 경우
-            refreshTokenRepository.delete(existRefreshToken);
             throw new TokenException(TokenErrorResult.INVALID_REFRESH_TOKEN); // 401 에러를 던져 재로그인을 요청
         } else {
             // 액세스 토큰 재발급
-            accessToken = jwtUtil.generateAccessToken(UUID.fromString(userId), ACCESS_TOKEN_EXPIRATION_TIME);
+            newAccessToken = jwtUtil.generateAccessToken(userId, ACCESS_TOKEN_EXPIRATION_TIME);
+
+            // 기존 리프레쉬 토큰 제거
+            refreshTokenRepository.deleteByUserId(userId);
         }
 
+        // 리프레쉬 토큰이 담긴 쿠키 생성 후 설정
+        Cookie newCookie = cookieUtil.createCookie(userId, REFRESH_TOKEN_EXPIRATION_TIME);
+        response.addCookie(newCookie);
+
+        // 새로운 리프레쉬 토큰 DB 저장
+        RefreshToken newRefreshToken = RefreshToken.builder()
+                .userId(userId)
+                .token(newCookie.getValue())
+                .build();
+        refreshTokenRepository.save(newRefreshToken);
+
+        // 새로운 액세스 토큰을 담아 반환
         return TokenResponse.builder()
-                .accessToken(accessToken)
+                .accessToken(newAccessToken)
                 .build();
     }
 }

--- a/backend/src/main/java/org/dgu/backend/util/CookieUtil.java
+++ b/backend/src/main/java/org/dgu/backend/util/CookieUtil.java
@@ -1,0 +1,41 @@
+package org.dgu.backend.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class CookieUtil {
+    private final JwtUtil jwtUtil;
+    private final String COOKIE_NAME = "refresh_token";
+
+    // 리프레쉬 토큰이 담긴 쿠키를 생성하는 메서드
+    public Cookie createCookie(UUID userId, long expirationMillis) {
+        String cookieValue = jwtUtil.generateRefreshToken(userId, expirationMillis);
+        Cookie cookie = new Cookie(COOKIE_NAME, cookieValue);
+        // 쿠키 속성 설정
+        cookie.setHttpOnly(true); // httponly 옵션 설정
+        cookie.setSecure(true);   // https 옵션 설정
+        cookie.setPath("/");      // 모든 곳에서 쿠키열람이 가능하도록 설정
+        cookie.setMaxAge((int) expirationMillis); // 쿠키 만료시간 설정
+        return cookie;
+    }
+
+    // 쿠키를 찾아 반환하는 메서드
+    public Cookie getCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(COOKIE_NAME)) {
+                    return cookie;
+                }
+            }
+        }
+
+        return null; // 해당하는 쿠키를 찾지 못한 경우 null 반환
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 로그인 성공 시, 리프레쉬 토큰은 쿠키에 담음
<img width="1006" alt="쿠키_리프레쉬토큰" src="https://github.com/KUSITMS-29th-TEAM-D/backend/assets/113084292/447e554f-64d4-4b61-bab3-bcf7fd1eac1f">

- 쿼리 파라미터에서 리프레쉬 토큰은 파싱할 필요 X

### 액세스 토큰 재발행 API도 쿠키 방식으로 리팩토링
<img width="1279" alt="쿠키_재발행_성공" src="https://github.com/KUSITMS-29th-TEAM-D/backend/assets/113084292/b0bae086-d6d9-4e76-aa7c-b88540020014">

- 프론트엔드에서 리프레쉬 토큰을 헤더로 보내줄 필요 X

### 액세스 토큰 재발행 API 요청을 하는 경우에도, 리프레쉬 토큰 갱신
<img width="1279" alt="쿠키_재발행_실패" src="https://github.com/KUSITMS-29th-TEAM-D/backend/assets/113084292/7c7b0ce0-8b9e-48ab-b5c1-8d9cf7eff0ca">

- 혹여나 리프레쉬 토큰이 탈취될 시를 대비
- 그러므로 동일한 리프레쉬 토큰으로 요청을 하면 401 에러가 발생함
=> 어차피 백엔드에서 관리하므로 그럴 일이 없기는 함

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

#9 

---

## 🎸 기타 사항 or 추가 코멘트

변경된 사항 노션에 작성해두었습니다~!